### PR TITLE
Changed TMF to netstandard1.6 for Core 1.0 projects

### DIFF
--- a/src/EFCoreTools.Core/EFCoreTools.Core.csproj
+++ b/src/EFCoreTools.Core/EFCoreTools.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EFCoreTools.SqlServer/EFCoreTools.SqlServer.csproj
+++ b/src/EFCoreTools.SqlServer/EFCoreTools.SqlServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6.1</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.2" />


### PR DESCRIPTION
Core 1.0 projects have issues with framework versions that don't exactly match the TMF. Since this project doesn't need any specific API's from 1.6.1, moving back to 1.6.